### PR TITLE
Refactor: Remove duplicate truthy parsing logic from isForceDialRequested

### DIFF
--- a/pkg/vpn/p2pAPI.go
+++ b/pkg/vpn/p2pAPI.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"strings"
 	"sync"
 	"time"
 
@@ -464,8 +463,7 @@ func Connect(node host.Host, dht *dht.IpfsDHT, registry *NodeRegistry) gin.Handl
 }
 
 func isForceDialRequested(c *gin.Context) bool {
-	force := strings.ToLower(strings.TrimSpace(c.Query("force")))
-	return force == "1" || force == "true" || force == "yes" || force == "on"
+	return parseTruthy(c.Query("force"))
 }
 
 // Disconnect function to handle the disconnect endpoint


### PR DESCRIPTION
Fixes #93 

 Reuse parseTruthy for force-dial query parsing

  isForceDialRequested in `p2pAPI.go` reimplemented the same truthy string parsing (1/true/yes/on) that already exists as
  parseTruthy in node_registry_api.go. This collapses the two into one helper so accepted values can't drift apart over
  time.

  - isForceDialRequested now delegates to parseTruthy
  - Dropped the now-unused strings import from p2pAPI.go

  No behavior change.