### PR TITLE
fix(ci): pin pnpm version in audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -23,13 +23,15 @@ jobs:
 
       # Set up Node.js environment
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 20
 
     # Install pnpm
     - name: Install pnpm
-      run: npm install -g pnpm@latest
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10.32.1
 
     # Install dependencies and build the React app
     - name: Build React App
@@ -89,14 +91,16 @@ jobs:
 
       # Set up Node.js environment
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           # cache: 'pnpm'
 
       # Install pnpm
       - name: Install pnpm
-        run: npm install -g pnpm@latest
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
 
       # Install dependencies and build the React app
       - name: Build React App


### PR DESCRIPTION
## Summary
- The audit workflow (`.github/workflows/audit.yml`) installs pnpm via `npm install -g pnpm@latest` on Node.js 18. pnpm's latest release now requires Node.js >=22.13, so the "Build React App" step fails immediately on every PR, before go vet/staticcheck/golint/tests ever run.
- This is why all open Renovate PRs currently show red checks, regardless of what they actually change.
- Fix mirrors the working config already used in `ci.yml`: Node 20 + pnpm pinned via `pnpm/action-setup@v4` (version 10.32.1) instead of an unpinned `pnpm@latest` install.

## Test plan
- [x] CI on this PR should now get past the "Build React App" step